### PR TITLE
Fix nested parentheses in markdown colours

### DIFF
--- a/app/src/app/components/note-viewer/elements/markdown/MarkdownElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/markdown/MarkdownElementComponent.tsx
@@ -423,7 +423,8 @@ export default class MarkdownElementComponent extends React.Component<IMarkdownE
 			type: 'listener',
 			listeners: {
 				'images.after': (event, text: string) =>
-					text.replace(/c\[([^\]]+)]\(([^)]+)\)/gi, (match, content, colour) =>
+					// e.g. c[this is green](green), or c[red](rgb(255, 0, 0))
+					text.replace(/c\[([^\]]+)]\(([^()]*(?:\([^()]*\)[^()]*)?)\)/gi, (match, content, colour) =>
 						`<span style="color: ${colour}">${content}</span>`
 					)
 			}


### PR DESCRIPTION
This fixes the markdown colour parser to support `c[this is red](rgb(255, 0, 0))`.

Fixes #209.