### PR TITLE
Remember encryption

### DIFF
--- a/app/src/app/components/explorer/app-settings/AppSettingsComponent.tsx
+++ b/app/src/app/components/explorer/app-settings/AppSettingsComponent.tsx
@@ -12,7 +12,7 @@ const AppSettingsComponent = (props: ConnectedProps<typeof appSettingsContainer>
 		<ul className="app-settings-component__action-list">
 			<li><Button flat onClick={() => Dialog.alert(`Nick hasn't done this thing yet`)}>Quick notebook switcher</Button></li> {/* TODO */}
 			<li><Button flat onClick={() => props.feelingLucky()}>I'm feeling lucky</Button></li>
-			<li><Button flat onClick={() => props.clearOldData()}>Clear old data</Button></li>
+			<li><Button flat onClick={() => props.clearOldData()}>Clear old/unused data</Button></li>
 		</ul>
 	</div>
 );

--- a/app/src/app/epics/CryptoEpics.ts
+++ b/app/src/app/epics/CryptoEpics.ts
@@ -1,9 +1,11 @@
 import { combineEpics, ofType } from 'redux-observable';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { EMPTY, from, Observable } from 'rxjs';
+import { catchError, concatMap, filter, map } from 'rxjs/operators';
 import { actions, MicroPadAction } from '../actions';
 import { Action } from 'redux-typescript-actions';
-import { EpicStore } from './index';
+import { EpicDeps, EpicStore } from './index';
+import { AddCryptoPasskeyAction } from '../types/ActionTypes';
+import { Dispatch } from 'redux';
 
 export const encryptNotepad$ = (action$: Observable<MicroPadAction>, store: EpicStore) =>
 	action$.pipe(
@@ -15,6 +17,23 @@ export const encryptNotepad$ = (action$: Observable<MicroPadAction>, store: Epic
 		}))
 	);
 
-export const cryptoEpics$ = combineEpics(
-	encryptNotepad$
+export const rememberPasskey$ = (action$: Observable<MicroPadAction>, store: EpicStore, { getStorage }: EpicDeps) =>
+	action$.pipe(
+		ofType<MicroPadAction, Action<AddCryptoPasskeyAction>>(actions.addCryptoPasskey.type),
+		filter(action => action.payload.remember && !!action.payload.notepadTitle),
+		concatMap((action: Action<AddCryptoPasskeyAction>) =>
+			from(getStorage().cryptoPasskeysStorage.setItem(action.payload.notepadTitle!, action.payload.passkey)).pipe(
+				map(() => action), // just keep the types happy
+				catchError(err => {
+					console.error(err);
+					return EMPTY;
+				})
+			)
+		),
+		filter(() => false)
+	);
+
+export const cryptoEpics$ = combineEpics<MicroPadAction, Dispatch, EpicDeps>(
+	encryptNotepad$,
+	rememberPasskey$
 );

--- a/app/src/app/epics/CryptoEpics.ts
+++ b/app/src/app/epics/CryptoEpics.ts
@@ -1,8 +1,6 @@
 import { combineEpics, ofType } from 'redux-observable';
-import { elvis, resolveElvis } from '../util';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { AddCryptoPasskeyAction } from '../types/ActionTypes';
 import { actions, MicroPadAction } from '../actions';
 import { Action } from 'redux-typescript-actions';
 import { EpicStore } from './index';
@@ -10,11 +8,11 @@ import { EpicStore } from './index';
 export const encryptNotepad$ = (action$: Observable<MicroPadAction>, store: EpicStore) =>
 	action$.pipe(
 		ofType<MicroPadAction, Action<string>>(actions.encryptNotepad.type),
-		map(action => ({
+		map(action => actions.addCryptoPasskey({
 			passkey: action.payload,
-			notepadTitle: resolveElvis(elvis(store.getState().notepads).notepad.item.title)
-		} as AddCryptoPasskeyAction)),
-		map(payload => actions.addCryptoPasskey(payload))
+			notepadTitle: store.getState().notepads.notepad?.item?.title,
+			remember: false
+		}))
 	);
 
 export const cryptoEpics$ = combineEpics(

--- a/app/src/app/epics/NotepadEpics.ts
+++ b/app/src/app/epics/NotepadEpics.ts
@@ -177,6 +177,7 @@ const restoreJsonNotepadAndLoadNote$ = (action$: Observable<MicroPadAction>, sto
 				map(({ notepad, passkey }) => ({ notepad: notepad.flatten(), passkey })),
 				map(({ notepad, passkey }): [string, FlatNotepad, string] => [result.noteRef, notepad, passkey]),
 				catchError(err => {
+					console.log('why');
 					console.error(err);
 
 					if (err instanceof DecryptionError) {

--- a/app/src/app/epics/NotepadEpics.ts
+++ b/app/src/app/epics/NotepadEpics.ts
@@ -141,7 +141,8 @@ const restoreJsonNotepad$ = (action$: Observable<MicroPadAction>) =>
 				return [
 					actions.addCryptoPasskey({
 						notepadTitle: res.notepad.title,
-						passkey: res.passkey
+						passkey: res.passkey,
+						remember: res.rememberKey
 					}),
 					actions.parseNpx.done({
 						params: '',
@@ -165,6 +166,7 @@ const restoreJsonNotepad$ = (action$: Observable<MicroPadAction>) =>
 		mergeMap((restoreActions: Action<any>[]) => [...restoreActions])
 	);
 
+type DecryptedShellContainer = Omit<EncryptNotepadAction, 'notepad'> & { notepad: FlatNotepad, noteRef: string };
 const restoreJsonNotepadAndLoadNote$ = (action$: Observable<MicroPadAction>, store: EpicStore, { getStorage }) =>
 	action$.pipe(
 		ofType<MicroPadAction, Action<RestoreJsonNotepadAndLoadNoteAction>>(actions.restoreJsonNotepadAndLoadNote.type),
@@ -174,10 +176,8 @@ const restoreJsonNotepadAndLoadNote$ = (action$: Observable<MicroPadAction>, sto
 				switchMap(notepadJson =>
 					from(fromShell(JSON.parse(notepadJson!), store.getState().notepadPasskeys[result.notepadTitle]))
 				),
-				map(({ notepad, passkey }) => ({ notepad: notepad.flatten(), passkey })),
-				map(({ notepad, passkey }): [string, FlatNotepad, string] => [result.noteRef, notepad, passkey]),
+				map((res): DecryptedShellContainer => ({ ...res, notepad: res.notepad.flatten(), noteRef: result.noteRef })),
 				catchError(err => {
-					console.log('why');
 					console.error(err);
 
 					if (err instanceof DecryptionError) {
@@ -190,10 +190,10 @@ const restoreJsonNotepadAndLoadNote$ = (action$: Observable<MicroPadAction>, sto
 			)
 		),
 		filterTruthy(),
-		concatMap(([noteRef, notepad, passkey]: [string, FlatNotepad, string]) => [
-			actions.addCryptoPasskey({ notepadTitle: notepad.title, passkey }),
-			actions.parseNpx.done({ params: '', result: notepad }),
-			actions.loadNote.started(noteRef)
+		concatMap(res => [
+			actions.addCryptoPasskey({ notepadTitle: res.notepad.title, passkey: res.passkey, remember: res.rememberKey }),
+			actions.parseNpx.done({ params: '', result: res.notepad }),
+			actions.loadNote.started(res.noteRef)
 		])
 	);
 
@@ -502,7 +502,8 @@ const moveObjAcrossNotepads$ = (actions$: Observable<MicroPadAction>, store: Epi
 				return [
 					actions.addCryptoPasskey({
 						notepadTitle: decryptedShell.notepad.title,
-						passkey: decryptedShell.passkey
+						passkey: decryptedShell.passkey,
+						remember: decryptedShell.rememberKey
 					}),
 					actions.parseNpx.done({
 						params: '',

--- a/app/src/app/epics/StorageEpics.ts
+++ b/app/src/app/epics/StorageEpics.ts
@@ -247,9 +247,15 @@ const clearLastOpenedNotepad$ = (action$: Observable<MicroPadAction>) =>
 		noEmit()
 	);
 
-const clearOldData$ = (action$: Observable<MicroPadAction>, store: EpicStore) =>
+const clearOldData$ = (action$: Observable<MicroPadAction>, store: EpicStore, { getStorage }: EpicDeps) =>
 	action$.pipe(
 		ofType<MicroPadAction, Action<{ silent: boolean }>>(actions.clearOldData.started.type),
+		tap(action => {
+			// Clear saved crypto passwords if the user clicked the manual button
+			if (!action.payload.silent) {
+				getStorage().cryptoPasskeysStorage.clear().catch(err => console.error(err));
+			}
+		}),
 		concatMap(action =>
 			from(cleanHangingAssets(NOTEPAD_STORAGE, ASSET_STORAGE, store.getState(), action.payload.silent)).pipe(
 				mergeMap((addPasskeyActions: Action<AddCryptoPasskeyAction>[]) => [

--- a/app/src/app/epics/StorageEpics.ts
+++ b/app/src/app/epics/StorageEpics.ts
@@ -132,7 +132,7 @@ const openNotepadFromStorage$ = (action$: Observable<MicroPadAction>, store: Epi
 					return from(fromShell(JSON.parse(json!), store.getState().notepadPasskeys[notepadTitle]));
 				}),
 				mergeMap((res: EncryptNotepadAction) => [
-					actions.addCryptoPasskey({ notepadTitle: res.notepad.title, passkey: res.passkey }),
+					actions.addCryptoPasskey({ notepadTitle: res.notepad.title, passkey: res.passkey, remember: res.rememberKey }),
 					actions.openNotepadFromStorage.done({ params: '', result: undefined }),
 					actions.parseNpx.done({ params: '', result: res.notepad.flatten() }),
 				]),
@@ -317,7 +317,7 @@ async function cleanHangingAssets(notepadStorage: LocalForage, assetStorage: Loc
 	const areNotepadsStillEncrypted = !!resolvedNotepadsOrErrors.find(res => res instanceof Error);
 
 	const resolvedNotepads = resolvedNotepadsOrErrors.filter((res): res is EncryptNotepadAction => !(res instanceof Error)).map((cryptoInfo: EncryptNotepadAction) => {
-		cryptoPasskeys.push(actions.addCryptoPasskey({ notepadTitle: cryptoInfo.notepad.title, passkey: cryptoInfo.passkey }));
+		cryptoPasskeys.push(actions.addCryptoPasskey({ notepadTitle: cryptoInfo.notepad.title, passkey: cryptoInfo.passkey, remember: false }));
 		return cryptoInfo.notepad;
 	});
 

--- a/app/src/app/epics/StorageEpics.ts
+++ b/app/src/app/epics/StorageEpics.ts
@@ -133,7 +133,7 @@ const openNotepadFromStorage$ = (action$: Observable<MicroPadAction>, store: Epi
 				}),
 				mergeMap((res: EncryptNotepadAction) => [
 					actions.addCryptoPasskey({ notepadTitle: res.notepad.title, passkey: res.passkey, remember: res.rememberKey }),
-					actions.openNotepadFromStorage.done({ params: '', result: undefined }),
+					actions.openNotepadFromStorage.done({ params: notepadTitle, result: undefined }),
 					actions.parseNpx.done({ params: '', result: res.notepad.flatten() }),
 				]),
 				catchError(err => {
@@ -141,11 +141,14 @@ const openNotepadFromStorage$ = (action$: Observable<MicroPadAction>, store: Epi
 
 					if (err instanceof DecryptionError) {
 						Dialog.alert(err.message);
+						return of(
+							actions.openNotepadFromStorage.failed({ params: notepadTitle, error: err })
+						);
 					} else {
 						Dialog.alert(`There was an error opening your notebook`);
 					}
 
-					return of(actions.openNotepadFromStorage.failed(err));
+					return of(actions.openNotepadFromStorage.failed({ params: notepadTitle, error: err }));
 				})
 			)
 		)

--- a/app/src/app/reducers/NotepadPasskeysReducer.ts
+++ b/app/src/app/reducers/NotepadPasskeysReducer.ts
@@ -1,5 +1,6 @@
 import { AbstractReducer } from './AbstractReducer';
 import { actions } from '../actions';
+import { DecryptionError } from '../services/CryptoService';
 
 export type NotepadPasskeysState = Record<string, string>;
 
@@ -18,5 +19,12 @@ export class NotepadPasskeysReducer extends AbstractReducer<NotepadPasskeysState
 				[action.payload.notepadTitle]: action.payload.passkey
 			};
 		}, actions.addCryptoPasskey);
+
+		this.handle((state, action) => {
+			if (!state[action.payload.params] || !(action.payload.error instanceof DecryptionError)) return state;
+			const newState = { ...state };
+			delete newState[action.payload.params];
+			return newState;
+		}, actions.openNotepadFromStorage.failed)
 	}
 }

--- a/app/src/app/root.css
+++ b/app/src/app/root.css
@@ -155,13 +155,13 @@ strong {
 }
 
 /* The background of the checked box */
-#app [type=checkbox].filled-in:checked+span:not(.lever):after {
+#app [type=checkbox].filled-in:checked+span:not(.lever):after, .vex [type=checkbox].filled-in:checked+span:not(.lever):after {
 	background-color: var(--mp-theme-accent);
 	border: 2px solid #5a5a5a;
 }
 
 /* The tick */
-#app [type=checkbox].filled-in:checked+span:not(.lever):before {
+#app [type=checkbox].filled-in:checked+span:not(.lever):before, .vex [type=checkbox].filled-in:checked+span:not(.lever):before {
 	border-right: 2px solid var(--mp-theme-accentContent);
 	border-bottom: 2px solid var(--mp-theme-accentContent);
 }

--- a/app/src/app/root.tsx
+++ b/app/src/app/root.tsx
@@ -185,10 +185,8 @@ async function hydrateStoreFromLocalforage() {
 	} else if (!!lastOpenedNotepad) {
 		const { notepadTitle, noteRef } = lastOpenedNotepad;
 		if (noteRef) {
-			console.log('h1');
 			store.dispatch(actions.restoreJsonNotepadAndLoadNote({ notepadTitle, noteRef }));
 		} else {
-			console.log('h2');
 			store.dispatch(actions.openNotepadFromStorage.started(notepadTitle));
 		}
 	}

--- a/app/src/app/root.tsx
+++ b/app/src/app/root.tsx
@@ -47,6 +47,7 @@ import { createSentryReduxEnhancer } from '../sentry';
 import { createDynamicCss } from './DynamicAppCss';
 import { hasRequiredFeatures } from '../unsupported-page/feature-detect';
 import { showUnsupportedPage } from '../unsupported-page/show-page';
+import { restoreSavedPasswords } from './services/CryptoService';
 
 window.MicroPadGlobals = {};
 
@@ -62,6 +63,8 @@ export const store = createStore(
 	baseReducer.initialState,
 	composeWithDevTools(compose(applyMiddleware(epicMiddleware), createSentryReduxEnhancer()))
 );
+
+export type MicroPadStore = typeof store;
 
 export const TOAST_HANDLER = new ToastEventHandler();
 
@@ -167,6 +170,8 @@ export function getStorage(): StorageMap {
 async function hydrateStoreFromLocalforage() {
 	await Promise.all(Object.values(getStorage()).map(storage => storage.ready()));
 
+	const restoreSavedPasswords$ = restoreSavedPasswords(store, CRYPTO_PASSKEYS_STORAGE);
+
 	const fontSize = await localforage.getItem<string>('font size');
 	if (!!fontSize) store.dispatch(actions.updateDefaultFontSize(fontSize));
 
@@ -184,6 +189,8 @@ async function hydrateStoreFromLocalforage() {
 
 	const theme = await localforage.getItem<ThemeName>('theme');
 	if (!!theme) store.dispatch(actions.selectTheme(theme));
+
+	await restoreSavedPasswords$;
 
 	// Reopen the last notebook + note
 	const lastOpenedNotepad = await localforage.getItem<string | LastOpenedNotepad>('last opened notepad');

--- a/app/src/app/root.tsx
+++ b/app/src/app/root.tsx
@@ -185,8 +185,10 @@ async function hydrateStoreFromLocalforage() {
 	} else if (!!lastOpenedNotepad) {
 		const { notepadTitle, noteRef } = lastOpenedNotepad;
 		if (noteRef) {
+			console.log('h1');
 			store.dispatch(actions.restoreJsonNotepadAndLoadNote({ notepadTitle, noteRef }));
 		} else {
+			console.log('h2');
 			store.dispatch(actions.openNotepadFromStorage.started(notepadTitle));
 		}
 	}

--- a/app/src/app/root.tsx
+++ b/app/src/app/root.tsx
@@ -85,11 +85,17 @@ export const SETTINGS_STORAGE = localforage.createInstance({
 	storeName: 'settings'
 });
 
+export const CRYPTO_PASSKEYS_STORAGE = localforage.createInstance({
+	name: 'MicroPad',
+	storeName: 'cryptoPasskeys'
+});
+
 export type StorageMap = {
 	notepadStorage: LocalForage,
 	assetStorage: LocalForage,
 	syncStorage: LocalForage,
 	settingsStorage: LocalForage,
+	cryptoPasskeysStorage: LocalForage,
 
 	/** @deprecated Use settingsStorage instead */
 	generalStorage: LocalForage
@@ -101,6 +107,7 @@ export function getStorage(): StorageMap {
 		assetStorage: ASSET_STORAGE,
 		syncStorage: SYNC_STORAGE,
 		settingsStorage: SETTINGS_STORAGE,
+		cryptoPasskeysStorage: CRYPTO_PASSKEYS_STORAGE,
 		generalStorage: localforage
 	};
 }

--- a/app/src/app/services/CryptoService.ts
+++ b/app/src/app/services/CryptoService.ts
@@ -14,7 +14,11 @@ export class DecryptionError extends Error {
 
 export async function fromShell(shell: NotepadShell, key?: string): Promise<EncryptNotepadAction> {
 	// Notepad is unencrypted, just return it
-	if (typeof shell.sections === 'object') return { notepad: await Translators.Json.toNotepadFromNotepad(shell), passkey: '' };
+	if (typeof shell.sections === 'object') return {
+		notepad: await Translators.Json.toNotepadFromNotepad(shell),
+		passkey: '',
+		rememberKey: false
+	};
 
 	// Prompt for decryption
 	const passkey: RememberMePromptRes | undefined = key != null

--- a/app/src/app/services/dialogs.ts
+++ b/app/src/app/services/dialogs.ts
@@ -13,6 +13,11 @@ type VexOpts = {
 	input?: string
 };
 
+export type RememberMePromptRes = {
+	secret: string,
+	remember: boolean
+};
+
 export class Dialog {
 	public static alert = (message: string) => Dialog.loadVex(Vex.dialog.alert, { message })
 
@@ -41,6 +46,34 @@ export class Dialog {
 			input: '<input name="vex" type="password" class="vex-dialog-prompt-input" />',
 		}
 	)
+
+	public static promptSecureRememberMe = (message: string): Promise<RememberMePromptRes | undefined> => {
+		const checkboxId = `vex__checkbox--${Dialog.ID_COUNT++}`;
+
+		return Dialog.loadVex<{ secret?: string, remember?: '1' } | undefined>(
+			Vex.dialog.open,
+			{
+				message,
+				input: `
+				<input name="secret" type="password" class="vex-dialog-prompt-input" />
+				<div class="vex-custom-input-wrapper" style="padding-top: 1em;">
+					<label for="${checkboxId}" style="color: var(--mp-theme-explorerContent);">
+						<input id="${checkboxId}" name="remember" class="filled-in" type="checkbox" class="vex-dialog-prompt-input" value="1" />
+						<span>Remember</span>
+					</label>
+				</div>
+			`,
+			}
+		).then(res => {
+			if (!res?.secret) return undefined;
+			return {
+				secret: res.secret,
+				remember: res.remember === '1'
+			};
+		});
+	};
+
+	private static ID_COUNT: number = 0;
 
 	private static loadVex<T>(vexFn: (opts: any) => void, opts: VexOpts): Promise<T> {
 		return new Promise<T>(resolve => {

--- a/app/src/app/types/ActionTypes.ts
+++ b/app/src/app/types/ActionTypes.ts
@@ -67,8 +67,9 @@ export type MoveNotepadObjectAction = {
 };
 
 export type EncryptNotepadAction = {
-	notepad: Notepad;
-	passkey: string;
+	notepad: Notepad,
+	passkey: string,
+	rememberKey?: boolean
 };
 
 export type AddCryptoPasskeyAction = {

--- a/app/src/app/types/ActionTypes.ts
+++ b/app/src/app/types/ActionTypes.ts
@@ -69,12 +69,13 @@ export type MoveNotepadObjectAction = {
 export type EncryptNotepadAction = {
 	notepad: Notepad,
 	passkey: string,
-	rememberKey?: boolean
+	rememberKey: boolean
 };
 
 export type AddCryptoPasskeyAction = {
-	notepadTitle?: string;
-	passkey: string;
+	notepadTitle?: string,
+	passkey: string,
+	remember: boolean
 };
 
 export type SearchIndex = {


### PR DESCRIPTION
This PR adds an option to remember passkeys for encrypted notebooks. The passkeys can be cleared with the "clear old/unused data" mechanism. The UX for what happens if the key that's saved is wrong isn't great, but this is still an improvement on what we have now.