### PR TITLE
Add different colours for drawings

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -18,5 +18,5 @@ module.exports = {
 	},
 	'roots': ['<rootDir>/src/', '<rootDir>/integration/src/'],
 	setupFilesAfterEnv: ['<rootDir>/integration/src/utils/jest-image.ts'],
-	testTimeout: 30000
+	testTimeout: 60000
 };

--- a/app/src/app/actions.ts
+++ b/app/src/app/actions.ts
@@ -124,7 +124,8 @@ export const actions = {
 	toggleSpellCheck: actionCreator<boolean | void>('TOGGLE_SPELL_CHECK'),
 	toggleWordWrap: actionCreator<boolean | void>('TOGGLE_WORD_WRAP'),
 	openModal: actionCreator<string>('OPEN_MODAL'),
-	setDrawMode: actionCreator<DrawMode>('SET_DRAW_MODE')
+	setDrawMode: actionCreator<DrawMode>('SET_DRAW_MODE'),
+	setDrawingLineColour: actionCreator<string>('SET_DRAWING_LINE_COLOUR')
 };
 
 export const READ_ONLY_ACTIONS: ReadonlySet<string> = new Set<string>([

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.css
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.css
@@ -1,0 +1,7 @@
+#drawing-element-editor__color-picker {
+	margin-top: 8px;
+}
+
+.drawing-element__view {
+	background-color: var(--mp-theme-drawingBackground);
+}

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { trim } from './trim-canvas';
 import { Resizable } from 're-resizable';
 // Remove unused imports later
-import { Col, Row } from 'react-materialize';
-import stringify from 'json-stringify-safe';
 import { Row, Select } from 'react-materialize';
 
 import * as FullScreenService from '../../../../services/FullscreenService';
@@ -57,18 +55,8 @@ export default class DrawingElementComponent extends React.Component<Props> {
 	private setDrawColour = (e, colour) => {
 		this.drawColour = colour;
 		this.drawingMode = "Colour";
-		console.log(colour);
-		//this.props.setDrawingLineColour(colour);
+		this.props.setDrawingLineColour(colour);
 		this.props.setDrawMode(DrawMode.Line);
-	}
-
-	private setMode = (e, mode) => {
-		this.drawingMode = mode;
-	}
-
-	private clearModeSelection = e => {
-		e.target.value = "";
-		e.target.placeholder = this.drawingMode;
 	}
 
 	render() {
@@ -76,7 +64,6 @@ export default class DrawingElementComponent extends React.Component<Props> {
 		if (!theme) return null;
 
 		const isEditing = element.args.id === elementEditing;
-
 		this.hasTrimmed = false;
 
 		if (isEditing) {
@@ -121,29 +108,18 @@ export default class DrawingElementComponent extends React.Component<Props> {
 					</Resizable>
 
 					<Row style={{ padding: '5px' }}>
-						<label hidden l="How does this work?" />
-						<Col>
-							<input type="text" list="drawing-modes" autoComplete="off" placeholder={this.drawingMode} onClick={this.clearModeSelection} onChange={e => this.setMode(e, e.target.value)}/>
-							<datalist key="drawing-modes" id="drawing-modes">
-								<option value={modes.COLOUR}/>
-								<option value={modes.RAINBOW}/>
-								<option value={modes.ERASER}/>
-							</datalist>
-						</Col>
-						<Col>
-							<input type="color" list="mp-drawing-colours" defaultValue={this.drawColour} onChange={e => this.setDrawColour(e, e.target.value)}/>
-							<datalist key="mp-drawing-colours" id="mp-drawing-colours">
-								<option value="#000000">Black</option>
-								<option value="#FFFFFF">White</option>
-								<option value="#E70000">Red</option>
-								<option value="#FFEF00">Yellow</option>
-								<option value="#00811F">Green</option>
-								<option value="#0044FF">Blue</option>
-								<option value="#FF8C00">Orange</option>
-								<option value="#760089">Purple</option>
-							</datalist>
-						</Col>
-						<label hidden l="New code" />
+						<input type="text" value={this.props.drawMode} onChange={e => {}} />
+						<input type="color" list="mp-drawing-colours" value={this.props.drawingLineColour} onChange={e => this.setDrawColour(e, e.target.value)}/>
+						<datalist key="mp-drawing-colours" id="mp-drawing-colours">
+							<option value="#000000">Black</option>
+							<option value="#FFFFFF">White</option>
+							<option value="#E70000">Red</option>
+							<option value="#FFEF00">Yellow</option>
+							<option value="#00811F">Green</option>
+							<option value="#0044FF">Blue</option>
+							<option value="#FF8C00">Orange</option>
+							<option value="#760089">Purple</option>
+						</datalist>
 						<Select label="Drawing mode" multiple={false} value={this.props.drawMode} onChange={e => this.props.setDrawMode(e.target.value as DrawMode)}>
 							<option value={DrawMode.Line}>Line</option>
 							<option value={DrawMode.ERASE}>Erase</option>
@@ -176,11 +152,8 @@ export default class DrawingElementComponent extends React.Component<Props> {
 		const { element, noteAssets } = this.props;
 
 		this.ongoingTouches = new OngoingTouches();
-		// Is drawing mode still needed?
-		this.drawingMode = modes.COLOUR;
 
 		const canvasElement = this.canvasElement;
-		console.log(!!canvasElement);
 		if (!!canvasElement) {
 
 			this.initCanvas();
@@ -324,9 +297,6 @@ export default class DrawingElementComponent extends React.Component<Props> {
 	}
 
 	private shouldErase = (event: PointerEvent): boolean => {
-
-		//return (this.drawingMode === modes.ERASER) || event.buttons === 32;
-
 		return this.props.drawMode === DrawMode.ERASE || event.buttons === 32;
 	}
 
@@ -339,11 +309,7 @@ export default class DrawingElementComponent extends React.Component<Props> {
 				: this.rainbowIndex * -1
 			: this.rainbowIndex;
 
-		//return (this.drawingMode === modes.RAINBOW) 	? rainbow[this.rainbowIndex += newIndex]
-		//						: this.drawColour;
-		// implement colour change
 		return (this.props.drawMode === DrawMode.RAINBOW) ? rainbow[this.rainbowIndex += newIndex] : this.props.drawingLineColour;
-
 	}
 
 	// Draws the outline of a line from pos1 to pos2 with the given width

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -37,6 +37,7 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 
 	private isErasing = false;
 	private isRainbow = false;
+	private drawColour = '#000000';
 	private rainbowIndex = 0;
 
 	render() {
@@ -271,7 +272,7 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 				: this.rainbowIndex * -1
 			: this.rainbowIndex;
 
-		return (this.isRainbow) ? rainbow[this.rainbowIndex += newIndex] : '#000000';
+		return (this.isRainbow) ? rainbow[this.rainbowIndex += newIndex] : this.drawColour;
 	}
 
 	// Draws the outline of a line from pos1 to pos2 with the given width

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -51,20 +51,20 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 	private drawColour = colours.BLACK;
 	private rainbowIndex = 0;
 
-        private setDrawColour = (e, colour) => {
-                this.drawColour = colour;
-                this.isErasing = false;
-                this.isRainbow = false;
+	private setDrawColour = (e, colour) => {
+		this.drawColour = colour;
+		this.isErasing = false;
+		this.isRainbow = false;
 
-                // Complete hack, but I don't know how to actually implement radio buttons
-                // Also doesn't really work when clicking on colours multiple times
-                // but it's enough to demo the idea
-                var buttons = Array.from((e.target as HTMLInputElement).parentNode.parentNode.parentNode.children);
-                buttons.forEach(b => b.firstChild.firstChild.checked = false);
-                (e.target as HTMLInputElement).checked = true;
-                console.log((e.target as HTMLInputElement).checked);
+		// Complete hack, but I don't know how to actually implement radio buttons
+		// Also doesn't really work when clicking on colours multiple times
+		// but it's enough to demo the idea
+		var buttons = Array.from((e.target as HTMLInputElement).parentNode.parentNode.parentNode.children);
+		buttons.forEach(b => b.firstChild.firstChild.checked = false);
+		(e.target as HTMLInputElement).checked = true;
+		console.log((e.target as HTMLInputElement).checked);
 
-        }
+	}
 
 	render() {
 		const { element, noteAssets, elementEditing, theme } = this.props;
@@ -322,7 +322,9 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 				: this.rainbowIndex * -1
 			: this.rainbowIndex;
 
-		return (this.isRainbow) ? rainbow[this.rainbowIndex += newIndex] : this.drawColour;
+
+		return (this.isRainbow) ? rainbow[this.rainbowIndex += newIndex]
+					: this.drawColour;
 	}
 
 	// Draws the outline of a line from pos1 to pos2 with the given width

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -20,6 +20,17 @@ const rainbow = [
 	'#760089'
 ];
 
+const colours = {
+        BLACK  : '#000000',
+        WHITE  : '#FFFFFF',
+        RED    : '#E70000',
+        YELLOW : '#FFEF00',
+        GREEN  : '#00811F',
+        BLUE   : '#0044FF',
+        ORANGE : '#FF8C00',
+        PURPLE : '#760089'
+};
+
 export interface IDrawingElementComponentProps extends INoteElementComponentProps {
 	isFullScreen: boolean;
 }
@@ -37,8 +48,23 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 
 	private isErasing = false;
 	private isRainbow = false;
-	private drawColour = '#000000';
+	private drawColour = colours.BLACK;
 	private rainbowIndex = 0;
+
+        private setDrawColour = (e, colour) => {
+                this.drawColour = colour;
+                this.isErasing = false;
+                this.isRainbow = false;
+
+                // Complete hack, but I don't know how to actually implement radio buttons
+                // Also doesn't really work when clicking on colours multiple times
+                // but it's enough to demo the idea
+                var buttons = Array.from((e.target as HTMLInputElement).parentNode.parentNode.parentNode.children);
+                buttons.forEach(b => b.firstChild.firstChild.checked = false);
+                (e.target as HTMLInputElement).checked = true;
+                console.log((e.target as HTMLInputElement).checked);
+
+        }
 
 	render() {
 		const { element, noteAssets, elementEditing, theme } = this.props;
@@ -91,6 +117,30 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 						</Col>
 						<Col>
 							<Checkbox label="Rainbow Mode 🏳️‍🌈" value="1" checked={this.isRainbow} filledIn onChange={e => this.isRainbow = (e.target as HTMLInputElement).checked} />
+						</Col>
+						<Col>
+							<Checkbox label="Black" value="1" checked={this.drawColour === colours.BLACK} filledIn onChange={e => this.setDrawColour(e, colours.BLACK)} />
+						</Col>
+						<Col>
+							<Checkbox label="White" value="1" checked={this.drawColour === colours.WHITE} filledIn onChange={e => this.setDrawColour(e, colours.WHITE)} />
+						</Col>
+						<Col>
+							<Checkbox label="Red" value="1" checked={this.drawColour === colours.RED} filledIn onChange={e => this.setDrawColour(e, colours.RED)} />
+						</Col>
+						<Col>
+							<Checkbox label="Yellow" value="1" checked={this.drawColour === colours.YELLOW} filledIn onChange={e => this.setDrawColour(e, colours.YELLOW)} />
+						</Col>
+						<Col>
+							<Checkbox label="Green" value="1" checked={this.drawColour === colours.GREEN} filledIn onChange={e => this.setDrawColour(e, colours.GREEN)} />
+						</Col>
+						<Col>
+							<Checkbox label="Blue" value="1" checked={this.drawColour === colours.BLUE} filledIn onChange={e => this.setDrawColour(e, colours.BLUE)} />
+						</Col>
+						<Col>
+							<Checkbox label="Orange" value="1" checked={this.drawColour === colours.ORANGE} filledIn onChange={e => this.setDrawColour(e, colours.ORANGE)} />
+						</Col>
+						<Col>
+							<Checkbox label="Purple" value="1" checked={this.drawColour === colours.PURPLE} filledIn onChange={e => this.setDrawColour(e, colours.PURPLE)} />
 						</Col>
 					</Row>
 

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -20,6 +20,13 @@ const rainbow = [
 	'#760089'
 ];
 
+const modes = {
+	COLOUR:'Colour',
+	RAINBOW:'Rainbow',
+	ERASER:'Eraser',
+};
+
+
 export interface IDrawingElementComponentProps extends INoteElementComponentProps {
 	isFullScreen: boolean;
 }
@@ -35,15 +42,22 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 	private ongoingTouches = new OngoingTouches();
 	private canvasImage?: Blob | null;
 
-	private isErasing = false;
-	private isRainbow = false;
-        private drawColour = "#000000";
+	private drawingMode = modes.COLOUR;
+	private drawColour = "#000000";
 	private rainbowIndex = 0;
 
 	private setDrawColour = (e, colour) => {
 		this.drawColour = colour;
-		this.isErasing = false;
-		this.isRainbow = false;
+		this.drawingMode = "Colour";
+	}
+
+	private setMode = (e, mode) => {
+		this.drawingMode = mode;
+	}
+
+	private clearModeSelection = e => {
+		e.target.value = "";
+		e.target.placeholder = this.drawingMode;
 	}
 
 	render() {
@@ -93,13 +107,25 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 
 					<Row style={{ padding: '5px' }}>
 						<Col>
-							<Checkbox label="Erase Mode" value="1" checked={this.isErasing} filledIn onChange={e => this.isErasing = (e.target as HTMLInputElement).checked} />
+							<input type="text" list="drawing-modes" autoComplete="off" placeholder={this.drawingMode} onClick={this.clearModeSelection} onChange={e => this.setMode(e, e.target.value)}/>
+							<datalist key="drawing-modes" id="drawing-modes">
+								<option value={modes.COLOUR}/>
+								<option value={modes.RAINBOW}/>
+								<option value={modes.ERASER}/>
+							</datalist>
 						</Col>
 						<Col>
-							<Checkbox label="Rainbow Mode 🏳️‍🌈" value="1" checked={this.isRainbow} filledIn onChange={e => this.isRainbow = (e.target as HTMLInputElement).checked} />
-						</Col>
-						<Col>
-							<input type="color" defaultValue={this.drawColour} onChange={e => this.setDrawColour(e, e.target.value)} />
+							<input type="color" list="mp-drawing-colours" defaultValue={this.drawColour} onChange={e => this.setDrawColour(e, e.target.value)}/>
+							<datalist key="mp-drawing-colours" id="mp-drawing-colours">
+								<option value="#000000">Black</option>
+								<option value="#FFFFFF">White</option>
+								<option value="#E70000">Red</option>
+								<option value="#FFEF00">Yellow</option>
+								<option value="#00811F">Green</option>
+								<option value="#0044FF">Blue</option>
+								<option value="#FF8C00">Orange</option>
+								<option value="#760089">Purple</option>
+							</datalist>
 						</Col>
 					</Row>
 					{!this.supportsPointerEvents && <p><em>Your browser seems to not support pointer events. Drawing may not work.</em></p>}
@@ -128,8 +154,7 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 		const { element, noteAssets } = this.props;
 
 		this.ongoingTouches = new OngoingTouches();
-		this.isErasing = false;
-		this.isRainbow = false;
+		this.drawingMode = modes.COLOUR;
 		if (!!this.canvasElement) {
 			this.initCanvas();
 
@@ -269,20 +294,20 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 	}
 
 	private shouldErase = (event: PointerEvent): boolean => {
-		return this.isErasing || event.buttons === 32;
+		return (this.drawingMode == modes.ERASER) || event.buttons === 32;
 	}
 
 	private getLineStyle = (): string => {
 		// Increment through the colours of the rainbow and reset to the beginning when reaching the last colour
-		const newIndex = (this.isRainbow)
+		const newIndex = (this.drawingMode == modes.RAINBOW)
 			? (this.rainbowIndex < rainbow.length - 1)
 				? 1
 				: this.rainbowIndex * -1
 			: this.rainbowIndex;
 
 
-		return (this.isRainbow) ? rainbow[this.rainbowIndex += newIndex]
-					: this.drawColour;
+		return (this.drawingMode == modes.RAINBOW) 	? rainbow[this.rainbowIndex += newIndex]
+								: this.drawColour;
 	}
 
 	// Draws the outline of a line from pos1 to pos2 with the given width

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -180,6 +180,7 @@ export default class DrawingElementComponent extends React.Component<Props> {
 		this.drawingMode = modes.COLOUR;
 
 		const canvasElement = this.canvasElement;
+		console.log(!!canvasElement);
 		if (!!canvasElement) {
 
 			this.initCanvas();

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -37,6 +37,7 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 
 	private isErasing = false;
 	private isRainbow = false;
+        private drawColour = "#000000";
 	private rainbowIndex = 0;
 
 	private setDrawColour = (e, colour) => {

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -1,9 +1,10 @@
-import { INoteElementComponentProps } from '../NoteElementComponent';
+import './DrawingElementComponent.css';
 import React from 'react';
+import { INoteElementComponentProps } from '../NoteElementComponent';
 import { trim } from './trim-canvas';
 import { Resizable } from 're-resizable';
 // Remove unused imports later
-import { Row, Select } from 'react-materialize';
+import { Col, Row, Select } from 'react-materialize';
 
 import * as FullScreenService from '../../../../services/FullscreenService';
 import { ConnectedProps } from 'react-redux';
@@ -25,13 +26,6 @@ const rainbow: ReadonlyArray<string> = [
 	'#760089'
 ];
 
-// Are modes here still necessary?
-const modes = {
-	COLOUR: 'Colour',
-	RAINBOW: 'Rainbow',
-	ERASER: 'Eraser',
-};
-
 type Props = ConnectedProps<typeof drawingElementConnector> & INoteElementComponentProps;
 
 
@@ -46,18 +40,7 @@ export default class DrawingElementComponent extends React.Component<Props> {
 	private ongoingTouches = new OngoingTouches();
 	private canvasImage?: Blob | null;
 
-	// Are modes still necessary?
-	private drawingMode = modes.COLOUR;
-	private drawColour = "#000000";
-
 	private rainbowIndex = 0;
-
-	private setDrawColour = (e, colour) => {
-		this.drawColour = colour;
-		this.drawingMode = "Colour";
-		this.props.setDrawingLineColour(colour);
-		this.props.setDrawMode(DrawMode.Line);
-	}
 
 	render() {
 		const { element, noteAssets, elementEditing, theme } = this.props;
@@ -102,29 +85,41 @@ export default class DrawingElementComponent extends React.Component<Props> {
 							// @ts-expect-error
 							ref={(e: DrawingCanvas | undefined) => this.canvasElement = e?.inner ?? null}
 							key={`drawing-canvas-${this.props.element.args.id}`}
+							className="drawing-element__view"
 							width="500"
 							height="450"
 							style={{ border: 'solid black 1px', touchAction: 'none' }} />
 					</Resizable>
 
 					<Row style={{ padding: '5px' }}>
-						<input type="text" value={this.props.drawMode} onChange={e => {}} />
-						<input type="color" list="mp-drawing-colours" value={this.props.drawingLineColour} onChange={e => this.setDrawColour(e, e.target.value)}/>
-						<datalist key="mp-drawing-colours" id="mp-drawing-colours">
-							<option value="#000000">Black</option>
-							<option value="#FFFFFF">White</option>
-							<option value="#E70000">Red</option>
-							<option value="#FFEF00">Yellow</option>
-							<option value="#00811F">Green</option>
-							<option value="#0044FF">Blue</option>
-							<option value="#FF8C00">Orange</option>
-							<option value="#760089">Purple</option>
-						</datalist>
-						<Select label="Drawing mode" multiple={false} value={this.props.drawMode} onChange={e => this.props.setDrawMode(e.target.value as DrawMode)}>
-							<option value={DrawMode.Line}>Line</option>
-							<option value={DrawMode.ERASE}>Erase</option>
-							<option value={DrawMode.RAINBOW}>Rainbow Mode 🏳️‍🌈</option>
-						</Select>
+						<Col s={6}>
+							<Select label="Drawing mode" multiple={false} value={this.props.drawMode} onChange={e => this.props.setDrawMode(e.target.value as DrawMode)}>
+								<option value={DrawMode.Line}>Line</option>
+								<option value={DrawMode.ERASE}>Erase</option>
+								<option value={DrawMode.RAINBOW}>Rainbow Mode 🏳️‍🌈</option>
+							</Select>
+						</Col>
+						<div className="input-field col s6"> {/* Manual <Col> so I can make this an <Input> too */}
+							<div className="select-wrapper"> {/* The colour picker should have the same style rules as a Select */}
+								<input
+									id="drawing-element-editor__color-picker"
+									type="color"
+									list="mp-drawing-colours"
+									value={this.props.drawingLineColour}
+									onChange={e => this.props.setDrawingLineColour(e.target.value)} />
+								<datalist key="mp-drawing-colours" id="mp-drawing-colours">
+									<option value="#000000">Black</option>
+									<option value="#FFFFFF">White</option>
+									<option value="#E70000">Red</option>
+									<option value="#FFEF00">Yellow</option>
+									<option value="#00811F">Green</option>
+									<option value="#0044FF">Blue</option>
+									<option value="#FF6900">Orange</option>
+									<option value="#760089">Purple</option>
+								</datalist>
+							</div>
+							<label id="drawing-element-editor__color-picker-label" htmlFor="drawing-element-editor__color-picker">Line colour</label>
+						</div>
 					</Row>
 					{!this.supportsPointerEvents && <p><em>Your browser seems to not support pointer events. Drawing may not work.</em></p>}
 				</div>
@@ -132,12 +127,12 @@ export default class DrawingElementComponent extends React.Component<Props> {
 		}
 
 		return (
-			<div style={{
+			<div className="drawing-element__view" style={{
 				overflow: 'hidden',
 				height: 'auto',
 				minWidth: '170px',
 				minHeight: '130px',
-				backgroundColor: !isEditing ? theme.drawingBackground : undefined
+				backgroundColor: theme.drawingBackground
 			}} onClick={this.openEditor}>
 				<img ref={elm => this.imageElement = elm!} style={{ height: 'auto', width: 'auto', minWidth: '0px', minHeight: '0px' }} src={noteAssets[element.args.ext!]} alt="" />
 			</div>

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -2,7 +2,7 @@ import { INoteElementComponentProps } from '../NoteElementComponent';
 import React from 'react';
 import { trim } from './trim-canvas';
 import { Resizable } from 're-resizable';
-import { Checkbox, Col, Row } from 'react-materialize';
+import { Col, Row } from 'react-materialize';
 import stringify from 'json-stringify-safe';
 import * as FullScreenService from '../../../../services/FullscreenService';
 
@@ -21,9 +21,9 @@ const rainbow = [
 ];
 
 const modes = {
-	COLOUR:'Colour',
-	RAINBOW:'Rainbow',
-	ERASER:'Eraser',
+	COLOUR:  'Colour',
+	RAINBOW: 'Rainbow',
+	ERASER:  'Eraser',
 };
 
 
@@ -294,19 +294,19 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 	}
 
 	private shouldErase = (event: PointerEvent): boolean => {
-		return (this.drawingMode == modes.ERASER) || event.buttons === 32;
+		return (this.drawingMode === modes.ERASER) || event.buttons === 32;
 	}
 
 	private getLineStyle = (): string => {
 		// Increment through the colours of the rainbow and reset to the beginning when reaching the last colour
-		const newIndex = (this.drawingMode == modes.RAINBOW)
+		const newIndex = (this.drawingMode === modes.RAINBOW)
 			? (this.rainbowIndex < rainbow.length - 1)
 				? 1
 				: this.rainbowIndex * -1
 			: this.rainbowIndex;
 
 
-		return (this.drawingMode == modes.RAINBOW) 	? rainbow[this.rainbowIndex += newIndex]
+		return (this.drawingMode === modes.RAINBOW) 	? rainbow[this.rainbowIndex += newIndex]
 								: this.drawColour;
 	}
 

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -37,25 +37,12 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 
 	private isErasing = false;
 	private isRainbow = false;
-	private drawColour = colours.BLACK;
 	private rainbowIndex = 0;
 
 	private setDrawColour = (e, colour) => {
-		console.log(e.target);
-		console.log(e.target.value);
-		console.log(colour);
 		this.drawColour = colour;
 		this.isErasing = false;
 		this.isRainbow = false;
-
-		// Complete hack, but I don't know how to actually implement radio buttons
-		// Also doesn't really work when clicking on colours multiple times
-		// but it's enough to demo the idea
-		/*var buttons = Array.from((e.target as HTMLInputElement).parentNode.parentNode.parentNode.children);
-		buttons.forEach(b => b.firstChild.firstChild.checked = false);
-		(e.target as HTMLInputElement).checked = true;
-		console.log((e.target as HTMLInputElement).checked);
-		//*/
 	}
 
 	render() {

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -57,6 +57,9 @@ export default class DrawingElementComponent extends React.Component<Props> {
 	private setDrawColour = (e, colour) => {
 		this.drawColour = colour;
 		this.drawingMode = "Colour";
+		console.log(colour);
+		//this.props.setDrawingLineColour(colour);
+		this.props.setDrawMode(DrawMode.Line);
 	}
 
 	private setMode = (e, mode) => {
@@ -338,7 +341,7 @@ export default class DrawingElementComponent extends React.Component<Props> {
 		//return (this.drawingMode === modes.RAINBOW) 	? rainbow[this.rainbowIndex += newIndex]
 		//						: this.drawColour;
 		// implement colour change
-		return (this.props.drawMode === DrawMode.RAINBOW) ? rainbow[this.rainbowIndex += newIndex] : '#000000';
+		return (this.props.drawMode === DrawMode.RAINBOW) ? rainbow[this.rainbowIndex += newIndex] : this.props.drawingLineColour;
 
 	}
 

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -122,34 +122,9 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 							<Checkbox label="Rainbow Mode 🏳️‍🌈" value="1" checked={this.isRainbow} filledIn onChange={e => this.isRainbow = (e.target as HTMLInputElement).checked} />
 						</Col>
 						<Col>
-							<Checkbox label="Black" value="1" checked={this.drawColour === colours.BLACK} filledIn onChange={e => this.setDrawColour(e, colours.BLACK)} />
-						</Col>
-						<Col>
-							<Checkbox label="White" value="1" checked={this.drawColour === colours.WHITE} filledIn onChange={e => this.setDrawColour(e, colours.WHITE)} />
-						</Col>
-						<Col>
-							<Checkbox label="Red" value="1" checked={this.drawColour === colours.RED} filledIn onChange={e => this.setDrawColour(e, colours.RED)} />
-						</Col>
-						<Col>
-							<Checkbox label="Yellow" value="1" checked={this.drawColour === colours.YELLOW} filledIn onChange={e => this.setDrawColour(e, colours.YELLOW)} />
-						</Col>
-						<Col>
-							<Checkbox label="Green" value="1" checked={this.drawColour === colours.GREEN} filledIn onChange={e => this.setDrawColour(e, colours.GREEN)} />
-						</Col>
-						<Col>
-							<Checkbox label="Blue" value="1" checked={this.drawColour === colours.BLUE} filledIn onChange={e => this.setDrawColour(e, colours.BLUE)} />
-						</Col>
-						<Col>
-							<Checkbox label="Orange" value="1" checked={this.drawColour === colours.ORANGE} filledIn onChange={e => this.setDrawColour(e, colours.ORANGE)} />
-						</Col>
-						<Col>
-							<Checkbox label="Purple" value="1" checked={this.drawColour === colours.PURPLE} filledIn onChange={e => this.setDrawColour(e, colours.PURPLE)} />
-						</Col>
-						<Col>
-							<input type="color" value={this.drawColour} onChange={e => this.setDrawColour(e, e.target.value)} />
+							<input type="color" defaultValue={this.drawColour} onChange={e => this.setDrawColour(e, e.target.value)} />
 						</Col>
 					</Row>
-
 					{!this.supportsPointerEvents && <p><em>Your browser seems to not support pointer events. Drawing may not work.</em></p>}
 				</div>
 			);

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -42,12 +42,35 @@ export default class DrawingElementComponent extends React.Component<Props> {
 
 	private rainbowIndex = 0;
 
+	/*
+		When selecting a colour, the drawing mode changes to 'Line' in order to immediately start drawing lines
+		The select box, where the user can choose a drawing mode, doesn't immediately update its value, still
+		displaying the old value (e.g. 'Eraser' instead of 'Line').
+		Subsequently selecting a different colour (without mode change), however, updates the select box. The
+		precise reason for this	behaviour is unknown.
+		Therefore, the solution (or rather, hack) is to cause a re-render by state change. Experimentally, this
+		only works within the 'render' method, not outside of it.
+
+		See also: https://github.com/MicroPad/MicroPad-Core/pull/384
+	*/
+	private causeStateChangeToReRenderOnColourSelect = false;
+
 	render() {
 		const { element, noteAssets, elementEditing, theme } = this.props;
 		if (!theme) return null;
 
 		const isEditing = element.args.id === elementEditing;
 		this.hasTrimmed = false;
+
+		// See above for the reason of this hack
+		// Mimicking the above mentioned manual solution, a different colour is selected and then reset.
+		// This will cause a re-render, but the condition won't be met again
+		if (this.causeStateChangeToReRenderOnColourSelect) {
+			var colour = this.props.drawingLineColour;
+			this.props.setDrawingLineColour("#000000");
+			this.props.setDrawingLineColour(colour);
+		}
+		this.causeStateChangeToReRenderOnColourSelect = false;
 
 		if (isEditing) {
 			return (
@@ -106,7 +129,10 @@ export default class DrawingElementComponent extends React.Component<Props> {
 									type="color"
 									list="mp-drawing-colours"
 									value={this.props.drawingLineColour}
-									onChange={e => this.props.setDrawingLineColour(e.target.value)} />
+									onChange={e => {
+											// Trigger re-render to update select box; See above for the reason
+											this.causeStateChangeToReRenderOnColourSelect = true;
+											this.props.setDrawingLineColour(e.target.value)}} />
 								<datalist key="mp-drawing-colours" id="mp-drawing-colours">
 									<option value="#000000">Black</option>
 									<option value="#FFFFFF">White</option>

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -52,6 +52,9 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 	private rainbowIndex = 0;
 
 	private setDrawColour = (e, colour) => {
+		console.log(e.target);
+		console.log(e.target.value);
+		console.log(colour);
 		this.drawColour = colour;
 		this.isErasing = false;
 		this.isRainbow = false;
@@ -59,11 +62,11 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 		// Complete hack, but I don't know how to actually implement radio buttons
 		// Also doesn't really work when clicking on colours multiple times
 		// but it's enough to demo the idea
-		var buttons = Array.from((e.target as HTMLInputElement).parentNode.parentNode.parentNode.children);
+		/*var buttons = Array.from((e.target as HTMLInputElement).parentNode.parentNode.parentNode.children);
 		buttons.forEach(b => b.firstChild.firstChild.checked = false);
 		(e.target as HTMLInputElement).checked = true;
 		console.log((e.target as HTMLInputElement).checked);
-
+		//*/
 	}
 
 	render() {
@@ -141,6 +144,9 @@ export default class DrawingElementComponent extends React.Component<IDrawingEle
 						</Col>
 						<Col>
 							<Checkbox label="Purple" value="1" checked={this.drawColour === colours.PURPLE} filledIn onChange={e => this.setDrawColour(e, colours.PURPLE)} />
+						</Col>
+						<Col>
+							<input type="color" value={this.drawColour} onChange={e => this.setDrawColour(e, e.target.value)} />
 						</Col>
 					</Row>
 

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -20,17 +20,6 @@ const rainbow = [
 	'#760089'
 ];
 
-const colours = {
-        BLACK  : '#000000',
-        WHITE  : '#FFFFFF',
-        RED    : '#E70000',
-        YELLOW : '#FFEF00',
-        GREEN  : '#00811F',
-        BLUE   : '#0044FF',
-        ORANGE : '#FF8C00',
-        PURPLE : '#760089'
-};
-
 export interface IDrawingElementComponentProps extends INoteElementComponentProps {
 	isFullScreen: boolean;
 }

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementComponent.tsx
@@ -21,9 +21,9 @@ const rainbow = [
 ];
 
 const modes = {
-	COLOUR:  'Colour',
+	COLOUR: 'Colour',
 	RAINBOW: 'Rainbow',
-	ERASER:  'Eraser',
+	ERASER: 'Eraser',
 };
 
 

--- a/app/src/app/components/note-viewer/elements/drawing/DrawingElementContainer.ts
+++ b/app/src/app/components/note-viewer/elements/drawing/DrawingElementContainer.ts
@@ -7,10 +7,12 @@ import { actions } from '../../../../actions';
 export const drawingElementConnector = connect(
 	(state: IStoreState) => ({
 		isFullScreen: state.app.isFullScreen,
-		drawMode: state.editor.drawMode
+		drawMode: state.editor.drawMode,
+		drawingLineColour: state.editor.drawingLineColour
 	}),
 	dispatch => ({
-		setDrawMode: (mode: DrawMode) => dispatch(actions.setDrawMode(mode))
+		setDrawMode: (mode: DrawMode) => dispatch(actions.setDrawMode(mode)),
+		setDrawingLineColour: (colour: string) => dispatch(actions.setDrawingLineColour(colour))
 	})
 );
 

--- a/app/src/app/reducers/EditorReducer.ts
+++ b/app/src/app/reducers/EditorReducer.ts
@@ -44,6 +44,6 @@ export class EditorReducer extends AbstractReducer<EditorState> {
 
 		this.handle((state, { payload }) => ({ ...state, drawMode: payload }), actions.setDrawMode);
 
-		this.handle((state, { payload }) => ({ ...state, drawingLineColour: payload }), actions.setDrawingLineColour);
+		this.handle((state, { payload }) => ({ ...state, drawingLineColour: payload, drawMode: DrawMode.Line }), actions.setDrawingLineColour);
 	}
 }

--- a/app/src/app/reducers/EditorReducer.ts
+++ b/app/src/app/reducers/EditorReducer.ts
@@ -43,5 +43,7 @@ export class EditorReducer extends AbstractReducer<EditorState> {
 		);
 
 		this.handle((state, { payload }) => ({ ...state, drawMode: payload }), actions.setDrawMode);
+
+		this.handle((state, { payload }) => ({ ...state, drawingLineColour: payload }), actions.setDrawingLineColour);
 	}
 }

--- a/app/src/app/reducers/EditorReducer.ts
+++ b/app/src/app/reducers/EditorReducer.ts
@@ -20,7 +20,7 @@ export class EditorReducer extends AbstractReducer<EditorState> {
 		shouldSpellCheck: true,
 		shouldWordWrap: true,
 		drawMode: DrawMode.Line,
-		drawingLineColour: '#000'
+		drawingLineColour: '#000000'
 	};
 
 	constructor() {


### PR DESCRIPTION
Currently, there are only the 3 modes "Erase", "Rainbow" and "Black" to draw with. For writing that leaves only a black pen.
This PR introduces the possibility to choose different colours to draw with.
Works on #65 

While allowing for arbitrary colour selection, default colours could also be provided in order to improve usability.

Possibly work on the rainbow logic.