### PR TITLE
Fixing markdown sandbox escape

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micropad",
-  "version": "3.30.3",
+  "version": "3.30.4",
   "private": true,
   "scripts": {
     "preinstall": "python3 ../libs/build-libs.py; ./get_precache_files.py > src/extraPrecacheFiles.ts",

--- a/app/src/app/components/note-viewer/elements/markdown/TodoListComponent.tsx
+++ b/app/src/app/components/note-viewer/elements/markdown/TodoListComponent.tsx
@@ -51,12 +51,10 @@ export default class TodoListComponent extends React.Component<ITodoListComponen
 		return new Promise<IProgressValues>(resolve => {
 			html
 				.then(htmlValue => {
-					// Create virtual element of the html given
-					const element = document.createElement('div');
-					element.innerHTML = htmlValue;
+					const virtualDOM = new DOMParser().parseFromString(htmlValue, 'text/html');
 
-					const done = element.querySelectorAll('.task-list-item input:checked').length;
-					const all = element.querySelectorAll('.task-list-item').length;
+					const done = virtualDOM.querySelectorAll('.task-list-item input:checked').length;
+					const all = virtualDOM.querySelectorAll('.task-list-item').length;
 
 					resolve({
 						done,

--- a/app/src/app/reducers/NotepadsReducer.ts
+++ b/app/src/app/reducers/NotepadsReducer.ts
@@ -18,9 +18,17 @@ export class NotepadsReducer extends MicroPadReducer<INotepadsStoreState> {
 	};
 
 	public reducer(state: INotepadsStoreState, action: Action): INotepadsStoreState {
-		const newState = this.reducerImpl(state, action);
-		if (newState.notepad && newState.notepad.item) {
-			newState.notepad.isReadOnly = isReadOnlyNotebook(newState.notepad?.item?.title ?? '');
+		let newState = this.reducerImpl(state, action);
+
+		const isReadOnly = isReadOnlyNotebook(newState.notepad?.item?.title ?? '');
+		if (newState.notepad && newState.notepad?.isReadOnly !== isReadOnly) {
+			newState = {
+				...newState,
+				notepad: {
+					...newState.notepad,
+					isReadOnly: isReadOnlyNotebook(newState.notepad?.item?.title ?? '')
+				}
+			};
 		}
 
 		return newState;


### PR DESCRIPTION
The markdown element's rendered HTML seemed to be escaping its sandbox. It turns out the sandbox escape was actually from the task list progress tracker! It's parsing the MD by placing it on an unattached DOM node. Turns out that still executes JS.

This fixes that by using `DOMParser`. This will ultimately be made redundant by the v4 case to modernise the markdown parsing in MicroPad that will remove the 2nd pass that counts checkboxes.